### PR TITLE
update/move orgs

### DIFF
--- a/repositories/arch-aur-pkgbuilds/main.tf
+++ b/repositories/arch-aur-pkgbuilds/main.tf
@@ -1,5 +1,5 @@
 module "github_repository" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository"
 
   repo_name        = var.repo_name
   repo_description = var.repo_description

--- a/repositories/arch-aur-pkgbuilds/terraform.tfvars
+++ b/repositories/arch-aur-pkgbuilds/terraform.tfvars
@@ -1,4 +1,4 @@
-repo_owner = "simonweald"
+repo_owner = "a7d-corp"
 
 repo_name        = "arch-aur-pkgbuilds"
 repo_description = "PKGBUILDS for AUR packages I maintain"

--- a/repositories/github-repo-management/_provider_github.tf
+++ b/repositories/github-repo-management/_provider_github.tf
@@ -1,0 +1,1 @@
+../_common/_provider_github.tf

--- a/repositories/github-repo-management/_variables.tf
+++ b/repositories/github-repo-management/_variables.tf
@@ -1,3 +1,9 @@
+# common vars
+
+variable "repo_owner" {
+  type = string
+}
+
 # github_repository
 
 variable "repo_name" {

--- a/repositories/github-repo-management/_versions.tf
+++ b/repositories/github-repo-management/_versions.tf
@@ -1,0 +1,1 @@
+../_common/_versions.tf

--- a/repositories/github-repo-management/main.tf
+++ b/repositories/github-repo-management/main.tf
@@ -1,5 +1,5 @@
 module "github_repository" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository"
 
   repo_name        = var.repo_name
   repo_description = var.repo_description
@@ -11,7 +11,7 @@ module "github_repository" {
 }
 
 module "github_repository_webhook" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository_webhook"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository_webhook"
 
   repo_name = var.repo_name
 

--- a/repositories/github-repo-management/terraform.tfvars
+++ b/repositories/github-repo-management/terraform.tfvars
@@ -1,3 +1,5 @@
+repo_owner = "a7d-corp"
+
 # github_repository
 
 repo_name        = "github-repo-management"

--- a/repositories/homeassistant/_variables.tf
+++ b/repositories/homeassistant/_variables.tf
@@ -37,9 +37,3 @@ variable "allow_rebase_merge" {
 variable "delete_branch_on_merge" {
   type = bool
 }
-
-# github_repository_collaborator
-
-variable "collaborator_name" {
-  type = string
-}

--- a/repositories/homeassistant/main.tf
+++ b/repositories/homeassistant/main.tf
@@ -1,5 +1,5 @@
 module "github_repository" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository"
 
   repo_name        = var.repo_name
   repo_description = var.repo_description
@@ -15,7 +15,7 @@ module "github_repository" {
 }
 
 module "github_repository_collaborator" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository_collaborator"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository_collaborator"
 
   repo_name         = var.repo_name
   collaborator_name = var.collaborator_name

--- a/repositories/homeassistant/main.tf
+++ b/repositories/homeassistant/main.tf
@@ -13,10 +13,3 @@ module "github_repository" {
   allow_rebase_merge     = var.allow_rebase_merge
   delete_branch_on_merge = var.delete_branch_on_merge
 }
-
-module "github_repository_collaborator" {
-  source = "github.com/a7d-corp/terraform-github-modules//github_repository_collaborator"
-
-  repo_name         = var.repo_name
-  collaborator_name = var.collaborator_name
-}

--- a/repositories/homeassistant/terraform.tfvars
+++ b/repositories/homeassistant/terraform.tfvars
@@ -11,5 +11,3 @@ has_issues = true
 allow_merge_commit     = false
 allow_rebase_merge     = false
 delete_branch_on_merge = true
-
-collaborator_name = "glitchcrab-bot"

--- a/repositories/homeassistant/terraform.tfvars
+++ b/repositories/homeassistant/terraform.tfvars
@@ -1,4 +1,4 @@
-repo_owner = "simonweald"
+repo_owner = "a7d-corp"
 
 repo_name        = "homeassistant"
 repo_description = "My personal Home Assistant config"

--- a/repositories/homelab-kubernetes-fleet/_provider_github.tf
+++ b/repositories/homelab-kubernetes-fleet/_provider_github.tf
@@ -1,0 +1,1 @@
+../_common/_provider_github.tf

--- a/repositories/homelab-kubernetes-fleet/_variables.tf
+++ b/repositories/homelab-kubernetes-fleet/_variables.tf
@@ -1,3 +1,11 @@
+# common vars
+
+variable "repo_owner" {
+  type = string
+}
+
+# repo vars
+
 variable "repo_name" {
   type = string
 }

--- a/repositories/homelab-kubernetes-fleet/_versions.tf
+++ b/repositories/homelab-kubernetes-fleet/_versions.tf
@@ -1,0 +1,1 @@
+../_common/_versions.tf

--- a/repositories/homelab-kubernetes-fleet/main.tf
+++ b/repositories/homelab-kubernetes-fleet/main.tf
@@ -1,5 +1,5 @@
 module "github_repository" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository"
 
   repo_name        = var.repo_name
   repo_description = var.repo_description

--- a/repositories/homelab-kubernetes-fleet/terraform.tfvars
+++ b/repositories/homelab-kubernetes-fleet/terraform.tfvars
@@ -1,3 +1,5 @@
+repo_owner = "a7d-corp"
+
 repo_name        = "homelab-kubernetes-fleet"
 repo_description = "Flux repo for Kubernetes homelab"
 repo_visibility  = "private"

--- a/repositories/sonar/_provider_github.tf
+++ b/repositories/sonar/_provider_github.tf
@@ -1,0 +1,1 @@
+../_common/_provider_github.tf

--- a/repositories/sonar/_variables.tf
+++ b/repositories/sonar/_variables.tf
@@ -1,3 +1,11 @@
+# common vars
+
+variable "repo_owner" {
+  type = string
+}
+
+# repo vars
+
 variable "repo_name" {
   type = string
 }

--- a/repositories/sonar/_variables.tf
+++ b/repositories/sonar/_variables.tf
@@ -37,9 +37,3 @@ variable "allow_rebase_merge" {
 variable "delete_branch_on_merge" {
   type = bool
 }
-
-# github_repository_collaborator
-
-variable "collaborator_name" {
-  type = string
-}

--- a/repositories/sonar/_versions.tf
+++ b/repositories/sonar/_versions.tf
@@ -1,0 +1,1 @@
+../_common/_versions.tf

--- a/repositories/sonar/main.tf
+++ b/repositories/sonar/main.tf
@@ -1,5 +1,5 @@
 module "github_repository" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository"
 
   repo_name        = var.repo_name
   repo_description = var.repo_description
@@ -15,7 +15,7 @@ module "github_repository" {
 }
 
 module "github_repository_collaborator" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository_collaborator"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository_collaborator"
 
   repo_name         = var.repo_name
   collaborator_name = var.collaborator_name

--- a/repositories/sonar/main.tf
+++ b/repositories/sonar/main.tf
@@ -13,10 +13,3 @@ module "github_repository" {
   allow_rebase_merge     = var.allow_rebase_merge
   delete_branch_on_merge = var.delete_branch_on_merge
 }
-
-module "github_repository_collaborator" {
-  source = "github.com/a7d-corp/terraform-github-modules//github_repository_collaborator"
-
-  repo_name         = var.repo_name
-  collaborator_name = var.collaborator_name
-}

--- a/repositories/sonar/terraform.tfvars
+++ b/repositories/sonar/terraform.tfvars
@@ -1,3 +1,5 @@
+repo_owner = "a7d-corp"
+
 repo_name        = "sonar"
 repo_description = "Sonar deploys a debugging container to a Kubernetes cluster"
 repo_visibility  = "public"

--- a/repositories/sonar/terraform.tfvars
+++ b/repositories/sonar/terraform.tfvars
@@ -11,5 +11,3 @@ has_issues = true
 allow_merge_commit     = false
 allow_rebase_merge     = false
 delete_branch_on_merge = true
-
-collaborator_name = "glitchcrab-bot"

--- a/repositories/terraform-github-modules/_provider_github.tf
+++ b/repositories/terraform-github-modules/_provider_github.tf
@@ -1,0 +1,1 @@
+../_common/_provider_github.tf

--- a/repositories/terraform-github-modules/_variables.tf
+++ b/repositories/terraform-github-modules/_variables.tf
@@ -1,3 +1,11 @@
+# common vars
+
+variable "repo_owner" {
+  type = string
+}
+
+# repo vars
+
 variable "repo_name" {
   type = string
 }

--- a/repositories/terraform-github-modules/_versions.tf
+++ b/repositories/terraform-github-modules/_versions.tf
@@ -1,0 +1,1 @@
+../_common/_versions.tf

--- a/repositories/terraform-github-modules/main.tf
+++ b/repositories/terraform-github-modules/main.tf
@@ -1,5 +1,5 @@
 module "github_repository" {
-  source = "github.com/glitchcrab/terraform-github-modules//github_repository"
+  source = "github.com/a7d-corp/terraform-github-modules//github_repository"
 
   repo_name        = var.repo_name
   repo_description = var.repo_description

--- a/repositories/terraform-github-modules/terraform.tfvars
+++ b/repositories/terraform-github-modules/terraform.tfvars
@@ -1,3 +1,5 @@
+repo_owner = "a7d-corp"
+
 repo_name        = "terraform-github-modules"
 repo_description = "Terraform modules to manage Github repos"
 repo_visibility  = "public"


### PR DESCRIPTION
- migrate sonar to a7d-corp
- move github-repo-management to a7d-corp
- move homeassistant to a7d-corp
- move arch-aur-pkgbuilds to a7d-corp
- migrate homelab-kubernetes-fleet to a7d-corp
- migrate terraform-github-modules to a7d-corp
- re-address modules
- remove collaborator from sonar
- remove collaborator from homeassistant
